### PR TITLE
support SQLite 3.8.8

### DIFF
--- a/checksums
+++ b/checksums
@@ -140,5 +140,5 @@ https://sqlite.org/2014/sqlite-autoconf-3080703.tar.gz 1999200 5cbe9aa4af1b32787
 https://sqlite.org/2014/sqlite-amalgamation-3080704.zip    1547492 c59060db42ab51e4a063f4f91ce4bc7aad5ab5fa 429777f515056bb2ddb96e3c0719616d
 https://sqlite.org/2014/sqlite-autoconf-3080704.tar.gz 1999230 70ca0b8884a6b145b7f777724670566e2b4f3cde 33bb8db0038317ce1b0480ca1185c7ba
 
-https://sqlite.org/2014/sqlite-amalgamation-3080800.zip    1568082 f16a0c38877e456e20967d198b1b33b658de0805 86afd36daa375c3a719cd1b699263d70
-https://sqlite.org/2014/sqlite-autoconf-3080800.tar.gz 2020708 abb7570b7e331ffede7f40f0037be6e0c03b73af 3a3caebf93308ddf5d120c393d9ecb82
+https://sqlite.org/2015/sqlite-amalgamation-3080800.zip    1568082 f16a0c38877e456e20967d198b1b33b658de0805 86afd36daa375c3a719cd1b699263d70
+https://sqlite.org/2015/sqlite-autoconf-3080800.tar.gz 2020708 abb7570b7e331ffede7f40f0037be6e0c03b73af 3a3caebf93308ddf5d120c393d9ecb82

--- a/checksums
+++ b/checksums
@@ -139,3 +139,6 @@ https://sqlite.org/2014/sqlite-autoconf-3080703.tar.gz 1999200 5cbe9aa4af1b32787
 
 https://sqlite.org/2014/sqlite-amalgamation-3080704.zip    1547492 c59060db42ab51e4a063f4f91ce4bc7aad5ab5fa 429777f515056bb2ddb96e3c0719616d
 https://sqlite.org/2014/sqlite-autoconf-3080704.tar.gz 1999230 70ca0b8884a6b145b7f777724670566e2b4f3cde 33bb8db0038317ce1b0480ca1185c7ba
+
+https://sqlite.org/2014/sqlite-amalgamation-3080800.zip    1568082 f16a0c38877e456e20967d198b1b33b658de0805 86afd36daa375c3a719cd1b699263d70
+https://sqlite.org/2014/sqlite-autoconf-3080800.tar.gz 2020708 abb7570b7e331ffede7f40f0037be6e0c03b73af 3a3caebf93308ddf5d120c393d9ecb82

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,9 @@ def fixup_download_url(url):
     if ver:
         ver=int(ver.group(0))
         if ver>=3071600:
-            if ver>=3080300:
+            if ver>=3080800:
+                year="2015"
+            elif ver>=3080300:
                 year="2014"
             else:
                 year="2013"

--- a/tools/checksums.py
+++ b/tools/checksums.py
@@ -7,6 +7,7 @@ import hashlib
 import re
 
 sqlitevers=(
+    '3080800',
     '3080704',
     '3080703',
     '3080702',
@@ -84,7 +85,9 @@ def fixup_download_url(url):
     if ver:
         ver=int(ver.group(0))
         if ver>=3071600:
-            if ver>=3080300:
+            if ver>=3080800:
+                year="2015"
+            elif ver>=3080300:
                 year="2014"
             else:
                 year="2013"


### PR DESCRIPTION
3.8.8 is the first 2015 release so it requires some additional tweaks to be supported.  Tested only on my machine -- feel free to scrap this and do it in anther way if I missed anything.