### PR TITLE
Add tox.ini for tox (http://tox.testrun.org/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ work/
 coverage/
 testdb
 /.coverage
+.tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+skipsdist = True
+envlist = py26, py27, py33, py34
+
+[testenv]
+commands =
+    python setup.py fetch --all build --enable-all-extensions install
+    # gcc -fPIC -bundle -o {envsitepackagesdir}/testextension.sqlext -I. -Isqlite3 src/testextension.c
+    python setup.py test


### PR DESCRIPTION
For testing across multiple Python versions -- e.g.:

    $ pip install tox
    ...
    $ tox
    ...
      py26: commands succeeded
      py27: commands succeeded
      py33: commands succeeded
      py34: commands succeeded
      congratulations :)

Hopefully this is still useful for apsw, despite its special build process.