### PR TITLE
Don't print traceback for shell sys.exit

### DIFF
--- a/tools/shell.py
+++ b/tools/shell.py
@@ -2942,7 +2942,7 @@ def main():
         _,_,cmds=s.process_args(sys.argv[1:])
         if len(cmds)==0:
             s.cmdloop()
-    except:
+    except Exception:
         v=sys.exc_info()[1]
         if getattr(v, "_handle_exception_saw_this", False):
             pass


### PR DESCRIPTION
E.g.:

```
[marca@marca-mac2 apsw]$ python tools/shell.py --version
3.8.8.2
Traceback (most recent call last):
  File "tools/shell.py", line 2942, in main
    _,_,cmds=s.process_args(sys.argv[1:])
  File "tools/shell.py", line 257, in process_args
    sys.exit(0)
SystemExit: 0
```

With this:

```
[marca@marca-mac2 apsw]$ python tools/shell.py --version
3.8.8.2
```
