### PR TITLE
add_shell: get __builtins__ directly instead of from __main__

### DIFF
--- a/src/apsw.c
+++ b/src/apsw.c
@@ -1866,11 +1866,10 @@ static void
 add_shell(PyObject *apswmodule)
 {
 #ifndef PYPY_VERSION
-  PyObject *res=NULL, *maindict=NULL, *apswdict, *msvciscrap=NULL;
+  PyObject *res=NULL, *apswdict, *msvciscrap=NULL;
 
-  maindict=PyModule_GetDict(PyImport_AddModule("__main__"));
   apswdict=PyModule_GetDict(apswmodule);
-  PyDict_SetItemString(apswdict, "__builtins__", PyDict_GetItemString(maindict, "__builtins__"));
+  PyDict_SetItemString(apswdict, "__builtins__", PyImport_AddModule("__builtin__"));
   PyDict_SetItemString(apswdict, "apsw", apswmodule);
 
   /* the toy compiler from microsoft falls over on string constants


### PR DESCRIPTION
In some situations, __main__.__builtins__ doesn't exist at the time
add_shell() is called.  The old code assumed that it does, and would segfault.

Before this commit:
```
$ python -c 'import IPython; \
             app = IPython.terminal.ipapp.TerminalIPythonApp.instance(); \
             app.user_ns = {}; app.initialize(); app.start()'
In [1]: import apsw
<segmentation fault>
```

This was first discovered when using pyflyby:
```
$ py
In [1]: import apsw
<segmentation fault>
```

To avoid that problem, this commit changes the code to import __builtin__ as a
module directly.