### PR TITLE
Use GitHub Actions to build binary wheels using cibuildwheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,71 @@
+name: build
+
+on:
+  push:
+    tags:
+      - '*.*.*-r*'
+  pull_request:  # Remove before merge!
+    branches:
+      - master
+
+jobs:
+
+  builds:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-python@v2
+
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.1.1
+
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BEFORE_BUILD: python setup.py fetch --all build --enable-all-extensions
+          CIBW_TEST_COMMAND: python {package}/tests.py
+          CIBW_SKIP: pp*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheelhouse
+          path: ./wheelhouse/*.whl
+
+  upload:
+    needs: builds
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install dependencies
+      run: |
+        pip install --upgrade pip
+
+    - name: Create source dist
+      run: python setup.py fetch --all sdist
+
+    - name: Stage wheels
+      uses: actions/download-artifact@v2
+      with:
+        name: wheelhouse
+        path: wheelhouse
+    - run: |
+        mv -v wheelhouse/* dist/
+        ls -l dist/
+
+    # - name: Publish package
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     user: __token__
+    #     password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Use GitHub Actions to build binary wheels using cibuildwheel.

- Before build: fetch all and build SQLite with all extensions
- Test build using tests.py
- Stash builds in wheelhouse as artifacts
- Fetch all when building sdist

TODO:

- [ ] Remove trigger on pull request
- [ ] Publish package to PyPI using token
