### PR TITLE
Enhance cibuildwheel workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,68 +1,135 @@
 name: build
 
 on:
-  push:
-    tags:
-      - '*.*.*-r*'
+
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Write 'PUBLISH' to publish to pypi. BEWARE! ARTIFACTS ARE IMMUTABLE AND CANNOT BE REPLACED ONCE PUBLISHED!
+      publish_test:
+        description: Write 'PUBLISH_TEST' to publish to test-pypi. BEWARE! ARTIFACTS ARE IMMUTABLE AND CANNOT BE REPLACED ONCE PUBLISHED!
 
 jobs:
 
-  builds:
+  wheels:
     runs-on: ${{ matrix.os }}
+
     strategy:
+      fail-fast: false
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        include:
+        - {os: ubuntu-20.04, CIBW_BUILD: "*-manylinux_x86_64"}
+        - {os: ubuntu-20.04, CIBW_BUILD: "*-manylinux_i686"}
+
+        - {os: ubuntu-20.04, CIBW_BUILD: "*-musllinux_x86_64"}
+        - {os: ubuntu-20.04, CIBW_BUILD: "*-musllinux_i686"}
+
+        - {os: ubuntu-20.04, CIBW_BUILD: cp36-manylinux_aarch64}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp37-manylinux_aarch64}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp38-manylinux_aarch64}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp39-manylinux_aarch64}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp310-manylinux_aarch64}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp36-manylinux_ppc64le}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp37-manylinux_ppc64le}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp38-manylinux_ppc64le}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp39-manylinux_ppc64le}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp310-manylinux_ppc64le}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp36-manylinux_s390x}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp37-manylinux_s390x}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp38-manylinux_s390x}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp39-manylinux_s390x}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp310-manylinux_s390x}
+
+        - {os: ubuntu-20.04, CIBW_BUILD: cp36-musllinux_aarch64}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp37-musllinux_aarch64}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp38-musllinux_aarch64}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp39-musllinux_aarch64}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp310-musllinux_aarch64}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp36-musllinux_ppc64le}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp37-musllinux_ppc64le}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp38-musllinux_ppc64le}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp39-musllinux_ppc64le}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp310-musllinux_ppc64le}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp36-musllinux_s390x}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp37-musllinux_s390x}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp38-musllinux_s390x}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp39-musllinux_s390x}
+        - {os: ubuntu-20.04, CIBW_BUILD: cp310-musllinux_s390x}
+
+        - {os: macos-10.15, CIBW_BUILD: "*-macosx_x86_64"}
+
+        - {os: windows-2019, CIBW_BUILD: "*-win32"}
+        - {os: windows-2019, CIBW_BUILD: "*-win_amd64"}
+
+    env:
+      CIBW_BUILD_VERBOSITY: 1
+      CIBW_BUILD: ${{ matrix.CIBW_BUILD }}
+      CIBW_ARCHS: all
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        id: cache-wheel
+        with:
+          path: wheelhouse
+          key: wheel-${{ matrix.CIBW_BUILD }}-${{ matrix.CIBW_ARCHS }}-${{ github.sha }}
+
+      - uses: docker/setup-qemu-action@v1
+        if: steps.cache-wheel.outputs.cache-hit != 'true' && runner.os == 'Linux'
+
+      - uses: pypa/cibuildwheel@v2.2.2
+        if: steps.cache-wheel.outputs.cache-hit != 'true'
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: ./wheelhouse/*.whl
+
+  sdist:
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.1.1
-
-      - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_BEFORE_BUILD: python setup.py fetch --all build --enable-all-extensions
-          CIBW_TEST_COMMAND: python {package}/tests.py
-          CIBW_SKIP: pp*
+      - run: python setup.py configure_pinned sdist
 
       - uses: actions/upload-artifact@v2
         with:
-          name: wheelhouse
-          path: ./wheelhouse/*.whl
+          name: dist
+          path: ./dist/*.tar.gz
 
-  upload:
-    needs: builds
+  upload_pypi:
+    needs: [ wheels, sdist ]
     runs-on: ubuntu-latest
+    if: needs.wheels.result == 'success' && needs.sdist.result == 'success' && github.event.inputs.publish == 'PUBLISH_TEST'
 
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - uses: actions/download-artifact@v2
       with:
-        python-version: 3.9
+        name: dist
+        path: dist
 
-    - name: Install dependencies
-      run: |
-        pip install --upgrade pip
-
-    - name: Create source dist
-      run: python setup.py fetch --all sdist
-
-    - name: Stage wheels
-      uses: actions/download-artifact@v2
+    - uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        name: wheelhouse
-        path: wheelhouse
-    - run: |
-        mv -v wheelhouse/* dist/
-        ls -l dist/
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        skip_existing: true
 
-    # - name: Publish package
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     user: __token__
-    #     password: ${{ secrets.PYPI_API_TOKEN }}
+  upload_pypi_test:
+    needs: [ wheels, sdist ]
+    runs-on: ubuntu-latest
+    if: needs.wheels.result == 'success' && needs.sdist.result == 'success' && github.event.inputs.publish == 'PUBLISH'
+
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: dist
+        path: dist
+
+    - uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        skip_existing: true
+        repository_url: https://test.pypi.org/legacy/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+requires-python = ">=3.6"
+
+[tool.cibuildwheel]
+before-all = "python3 setup.py configure_pinned"
+skip = "pp*"
+test-command = "python {package}/tests.py"


### PR DESCRIPTION
This adds various enhancements to the `cibuildwheel` workflow, in hopes of making it align well with release and build processes.

I can change or split up this PR as you like. My intent is to throw a lot of enhancements at the wall, and see which ones you'd like to keep.

## ~~`master` broken?~~

~~**NOTE** that the `cibuildwheel` jobs currently fail because `tests.py` segfaults on every platform.~~

~~I tried rebasing this change on ab4c2a52006b90f58922762224f1e5e6f370b746, and the tests passed then, on every platform. I haven't done this rebase in this PR, due to the conflict with the existing `build.yml`.~~

~~I presume this means it would actually be useful to have automatic building and testing on every PR, so I restored the PR trigger for this workflow.~~

## Changes in this PR

* **Added `setup.py configure_pinned`**: modifies `setup.cfg` in-place to pin the sqlite version
* **Move `cibuildwheel` config into `pyproject.toml`**
  * Makes it easier to do local test builds, getting consistent config
* ~~**Default to building against the "mached" version of sqlite**~~
  * ~~so `apsw-3.36.0` builds against sqlite 3.36.0), per [this comment](https://github.com/rogerbinns/apsw/issues/310#issuecomment-976239211). This guarantee will make it more straightforward for apps to declare a dependency on a particular version of sqlite/apsw.~~
  * ~~The current behavior of using the latest sqlite is available using `setup.py fetch --version=latest`~~
* **Workflow *does not* automatically run on new git tags**
  * Since the build may fail, I presume it's nicer to be able to (re-)run the build at will, without changing git tags.
* **Workflow can be manually run**
  * When manually run, we will build wheels in the full set of flavors supported by `cibuildwheel`.
  * This configuration splits the work into roughly-equal-time jobs. Building all flavors takes about an hour, as the emulated architectures take a long time.
* **Optional uploading to PyPI**
  * This option is only available when the workflow is manually run.
  * PyPI API keys are stored as github secrets.
* ~~**Workflow will automatically run for each PR**~~
  * ~~In [the original PR](https://github.com/rogerbinns/apsw/pull/313) this was a non-feature. However the build is currently broken in master so I presume this would be useful!~~
  * ~~When triggered by a PR, we will do a limited selection of build flavors, not the full selection, for time's sake.~~
* **Build artifacts are cached for fast re-runs**
  * You can run several build workflows for testing, then re-run the last one with PyPI upload enabled.
  * This plus `fail-fast: false` is also helpful to recover from spurious failures (e.g. failing to fetch sqlite source). If one job fails, just re-run the whole workflow, and any successful artifacts will be picked up from the cache on the second run.
* ~~**Automatically update `cibuildwheel` using `dependabot`**~~
  * ~~Per https://cibuildwheel.readthedocs.io/en/stable/faq/#option-1-github-action~~

## Proposed release procedure

1. Run the build workflow, *without* PyPI upload
2. If all build flavors succeed, add a git tag
3. Re-run the build workflow *with* PyPI upload. The build artifacts will be cached, so the re-run will be fast

## Example run

~~[This workflow run](https://github.com/AllSeeingEyeTolledEweSew/apsw/actions/runs/1498135732) shows all build flavors. I ran this with the change rebased on ab4c2a52006b90f58922762224f1e5e6f370b746, so the tests would pass. I enabled PyPI upload for demonstration purposes, which obviously fails for lack of the API secret.~~

## Optional further enhancements

* **Drop support for `ppc64le` and `s390x`**
  * These platforms are rare, and you may want to wait until some user actually requests support for them before spending time and storage on them.
  * I think `aarch64` is worth keeping, as I believe this covers modern raspberry pi and linux/docker on M1 Macs.
* **Native artifacts for M1 Macs**
  * `cibuildwheel` can cross-compile these wheels, but they cannot be tested. See [this FAQ entry](https://cibuildwheel.readthedocs.io/en/stable/faq/#apple-silicon). Github Actions doesn't have M1 mac runners yet (see https://github.com/actions/runner/issues/805). AFAICT everyone building native wheels for M1 macs are using self-hosted CI solutions.