### PR TITLE
Add 2022 SQLite3 version info

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,9 @@ def fixup_download_url(url):
     if ver:
         ver = int(ver.group(0))
         if ver >= 3071600:
-            if ver >= 3340100:
+            if ver >= 3370200:
+                year = "2022"
+            elif ver >= 3340100:
                 year = "2021"
             elif ver >= 3310000:
                 year = "2020"

--- a/tools/checksums.py
+++ b/tools/checksums.py
@@ -58,7 +58,9 @@ def fixup_download_url(url):
     if ver:
         ver = int(ver.group(0))
         if ver >= 3071600:
-            if ver >= 3340100:
+            if ver >= 3370200:
+                year = "2022"
+            elif ver >= 3340100:
                 year = "2021"
             elif ver >= 3310000:
                 year = "2020"


### PR DESCRIPTION
Adding 2022 year information for 3,37.2 so a setup build with 3.37.2 knows where to pull down the source for SQLite from.