### PR TITLE
Fix pypycompat.c no included in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ include src/blob.c
 include src/connection.c
 include src/cursor.c
 include src/exceptions.c
+include src/pypycompat.c
 include src/pyutil.c
 include src/statementcache.c
 include src/traceback.c


### PR DESCRIPTION
Fixes `src/apsw.c(132): fatal error C1083: Cannot open include file: 'pypycompat.c': No such file or directory` when building from source distribution [apsw-3.37.0-r1.zip](https://github.com/rogerbinns/apsw/releases/download/3.37.0-r1/apsw-3.37.0-r1.zip) on PyPy 7.3.7 for Windows.