### PR TITLE
docs: Fix a few typos

### DIFF
--- a/src/vfs.c
+++ b/src/vfs.c
@@ -1501,7 +1501,7 @@ apswvfspy_xNextSystemCall(APSWVFS *self, PyObject *args, PyObject *kwds)
    Unregisters the VFS making it unavailable to future database
    opens. You do not need to call this as the VFS is automatically
    unregistered by when the VFS has no more references or open
-   datatabases using it. It is however useful to call if you have made
+   databases using it. It is however useful to call if you have made
    your VFS be the default and wish to immediately make it be
    unavailable. It is safe to call this routine multiple times.
 

--- a/tools/shell.py
+++ b/tools/shell.py
@@ -1546,7 +1546,7 @@ Enter SQL statements terminated with a ";"
 
           https://sqlite.org/datatype3.html
 
-        Another alternative is to create a tempory table, insert the
+        Another alternative is to create a temporary table, insert the
         values into that and then use casting.
 
           CREATE TEMPORARY TABLE import(a,b,c);


### PR DESCRIPTION
There are small typos in:
- src/vfs.c
- tools/shell.py

Fixes:
- Should read `temporary` rather than `tempory`.
- Should read `databases` rather than `datatabases`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md