### PR TITLE
fix typo practise -> practice

### DIFF
--- a/apsw/bestpractice.py
+++ b/apsw/bestpractice.py
@@ -83,8 +83,8 @@ def apply(which: tuple[Callable, ...]) -> None:
         else:
             func()
 
-    def best_practise_connection_apply(connection: apsw.Connection):
+    def best_practice_connection_apply(connection: apsw.Connection):
         for func in hooks:
             func(connection)
 
-    apsw.connection_hooks.append(best_practise_connection_apply)
+    apsw.connection_hooks.append(best_practice_connection_apply)

--- a/apsw/speedtest.py
+++ b/apsw/speedtest.py
@@ -554,7 +554,7 @@ statements_nobindings:
 
   In theory all the tests above should run in almost identical time
   as well as when using the SQLite command line shell.  This tool
-  shows you what happens in practise.
+  shows you what happens in practice.
     \n"""
 
 if __name__ == "__main__":

--- a/doc/benchmarking.rst
+++ b/doc/benchmarking.rst
@@ -98,7 +98,7 @@ underlying queries are based on `SQLite's speed test
     
       In theory all the tests above should run in almost identical time
       as well as when using the SQLite command line shell.  This tool
-      shows you what happens in practise.
+      shows you what happens in practice.
         
     
 

--- a/doc/bestpractice.rst
+++ b/doc/bestpractice.rst
@@ -7,7 +7,7 @@ Explanation
 Because SQLite keeps very strong backwards compatibility, there are
 several quirks and settings improvements that are not automatically
 done.  This module does them for you, and keeps up to date with SQLite
-best practises.  Several are described in the `SQLite documentation
+best practices.  Several are described in the `SQLite documentation
 <https://www.sqlite.org/quirks.html>`__.
 
 Functions whose name begin with :code:`library` apply to the SQLite
@@ -23,7 +23,7 @@ You can call the individual functions, or
 
     import apsw.bestpractice
 
-    apsw.bestpractise.apply(apsw.bestpractice.recommended)
+    apsw.bestpractice.apply(apsw.bestpractice.recommended)
 
 API
 ---

--- a/doc/tips.rst
+++ b/doc/tips.rst
@@ -81,7 +81,7 @@ to all other Cursors on the same connection.  This still applies if
 you start transactions.  Connections are isolated from each other.
 
 Cursor objects are obtained by :meth:`Connection.cursor` and are very
-cheap.  It is best practise to not re-use them, and instead get a new one
+cheap.  It is best practice to not re-use them, and instead get a new one
 each time.  If you don't, code refactoring and nested loops can unintentionally
 use the same cursor object which will not crash but will cause hard to
 diagnose behaviour in your program.


### PR DESCRIPTION
A few typo errors for practice are fixed.
They occur in documentation when referring to `bestpractice` module and in general.