### PR TITLE
Remove include of <alloca.h>

### DIFF
--- a/src/apsw.c
+++ b/src/apsw.c
@@ -104,8 +104,6 @@ API Reference
 #include <stdarg.h>
 #ifdef _MSC_VER
 #include <malloc.h>
-#else
-#include <alloca.h>
 #endif
 
 /* Get the version number */


### PR DESCRIPTION
alloca.h has been deprecated for a long time, and no modern system should need it (and some do not even have it). While there are some references to alloca() in the source, none are in src/apsw.c

Fixes build on at least NetBSD