### PR TITLE
Include older supported Pythons when building Linux ARM wheels

### DIFF
--- a/.github/workflows/build-testpypi.yml
+++ b/.github/workflows/build-testpypi.yml
@@ -31,6 +31,12 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
+          python_tag:
+            - cp38
+            - cp39
+            - cp310
+            - cp311
+            - cp312
           arch: [aarch64]
 
       steps:
@@ -44,16 +50,15 @@ jobs:
         - name: Build wheels
           uses: pypa/cibuildwheel@v2.19
           env:
-            CIBW_SKIP: pp*
+            CIBW_BUILD: ${{ matrix.python_tag }}-*
             CIBW_ARCHS_LINUX: ${{ matrix.arch }}
-            CIBW_PROJECT_REQUIRES_PYTHON: ">= 3.10"
             CIBW_BEFORE_BUILD: python -c "import shutil ; shutil.copyfile('tools/setup-pypi.cfg','setup.apsw')"
             CIBW_TEST_COMMAND: python -m apsw.tests -v
             APSW_HEAVY_DURATION: 2
 
         - uses: actions/upload-artifact@v4
           with:
-            name: dist-qemu-${{ matrix.arch }}
+            name: dist-qemu-${{ matrix.python_tag }}-${{ matrix.arch }}
             path: ./wheelhouse/*.whl
 
 


### PR DESCRIPTION
This PR splits the build jobs for emulated targets into one build per Python version. This should allow continuing building ARM wheels for all supported Python versions when it would normally cause timeouts (https://github.com/rogerbinns/apsw/commit/50d312cac1ebe64043219af70ed0eed5cc75efb2). This should speed up the wheel build in general too since the current 1h 45m build of 3 different Python versions gets split in three. There could also be some benefit to doing something similar for Linux builds, though the split doesn't necessarily have to be by Python version, it could also be by `manylinux`/`musllinux` variants and/or by `x86_64`/`i686` variants. I didn't do any of that here since I'm not sure how important the CI wheel build performance is for you but I am open to doing so.

The main downside I can see here is having to explicitly specify Python versions that you want to build as opposed to relying on cibuildwheel to remove versions not supported by apsw *and* to include new versions once they reach the release candidate status. The former requires bumping version in `setup.py` and the latter requires bumping cibuildwheel version anyway though so updating the version list at the same time probably isn't a big deal? If it is, it is possible to [generate the matrix dynamically with a dependant job](https://www.kenmuse.com/blog/dynamic-build-matrices-in-github-actions/) but since it seemed overly complicated for quite a small gain, I figured it's unlikely to be worth doing.

Example workflow run: https://github.com/Jackenmen/apsw/actions/runs/9907470604

Note that I assumed that you probably would want to limit this to TEST pypi workflow first but if not, I can update the `build-pypi.yml` workflow as well.