### PR TITLE
pysqlite.rst: fix reference to virtual tables

### DIFF
--- a/doc/pysqlite.rst
+++ b/doc/pysqlite.rst
@@ -43,7 +43,7 @@ module:
   through Python 3.14.
 
 * APSW gives all functionality of SQLite including :doc:`full text
-  search (FTS5) <textsearch>`, :doc:`session`, `:ref:`virtual tables
+  search (FTS5) <textsearch>`, :doc:`session`, :ref:`virtual tables
   <virtualtables>`, :ref:`VFS`, :ref:`BLOB I/O <blobio>`,
   :ref:`backups <backup>`, :meth:`logging <apsw.ext.log_sqlite>`,
   :meth:`file control <Connection.file_control>`, and :meth:`tracing


### PR DESCRIPTION
Before this change, the reference to Virtual Tables in https://rogerbinns.github.io/apsw/pysqlite.html#what-apsw-does-better was rendered incorrectly, due to a spurious "`".

See this screenshot from 2025-06-17:
![image](https://github.com/user-attachments/assets/065dd7cd-0389-4251-8c13-912d004ff70a)
