### PR TITLE
remove TypeAlias use for collections.abc.Mapping

### DIFF
--- a/apsw/__init__.pyi
+++ b/apsw/__init__.pyi
@@ -7,7 +7,7 @@ import array
 import types
 
 # Anything that resembles a dictionary
-Mapping: TypeAlias = collections.abc.Mapping
+Mapping = collections.abc.Mapping
 
 # Anything that resembles a sequence of bytes
 if sys.version_info >= (3, 12):

--- a/src/apswtypes.py
+++ b/src/apswtypes.py
@@ -6,7 +6,7 @@ import array
 import types
 
 # Anything that resembles a dictionary
-Mapping: TypeAlias = collections.abc.Mapping
+Mapping = collections.abc.Mapping
 
 # Anything that resembles a sequence of bytes
 if sys.version_info >= (3, 12):


### PR DESCRIPTION
prior use of TypeAlias here is no longer accepted by pyright, with [pyright saying this is by design](https://github.com/microsoft/pyright/issues/10679#issuecomment-3040599524).

While Eric provided an option that retains it as a type alias in the linked issue, simply removing the TypeAlias and using it as a value works fine for all uses of it in the typestubs