### PR TITLE
Dont call into python if before init or after finalization

### DIFF
--- a/src/apsw.c
+++ b/src/apsw.c
@@ -566,6 +566,10 @@ apsw_logger(void *arg, int errcode, const char *message)
   PyGILState_STATE gilstate;
   PyObject *res = NULL;
 
+  /* Cannot call back into interpreter */
+  if (!Py_IsInitialized() || Py_IsFinalizing())
+    return;
+
   gilstate = PyGILState_Ensure();
   MakeExistingException();
   assert(arg == logger_cb);


### PR DESCRIPTION
When an application sets up logging with `apsw.bestpractice.library_logging()`, `apsw_logger` calls `PyGILState_Ensure()` with no check for whether the interpreter is still alive. If SQLite emits a log message after `Py_Finalize` has run (e.g. from a library that closes a SQLite handle in an `atexit` handler) `PyGILState_Ensure()` dereferences freed memory and the process segfaults

## Environment

| Component | Version |
|-----------|---------|
| apsw      | 3.51.0.0 |
| CPython   | 3.13.13 |
| SQLite    | 3.51.2 (shared library) |
| OS        | Linux x86\_64 |

I found this working with [PROJ](https://pypi.org/project/pyproj/), which keeps a cached SQLite handle and closes it from a static destructor at process exit. Any user with a similar setup can trigger this crash

## GDB backtrace

```
Thread 1 "python" received signal SIGSEGV, Segmentation fault.
0x00007ffff7ad2ce0 in new_threadstate () from .../libpython3.13.so.1.0
#0  0x00007ffff7ad2ce0 in new_threadstate () from .../libpython3.13.so.1.0
#1  0x00007ffff7ad3152 in PyGILState_Ensure () from .../libpython3.13.so.1.0
#2  0x00007ffdd32e114b in apsw_logger () from .../apsw/__init__.cpython-313-x86_64-linux-gnu.so
#3  0x00007ffff510eb30 in renderLogMsg () from .../libsqlite3.so
#4  0x00007ffff510ec30 in sqlite3_log () from .../libsqlite3.so
#5  0x00007ffff510ed19 in verifyDbFile () from .../libsqlite3.so
#6  0x00007ffff510fba3 in unixClose () from .../libsqlite3.so
#7  0x00007ffde074fe9e in osgeo::proj::VFSClose(sqlite3_file*) () from .../libproj.so.25
#8  0x00007ffff516fc75 in sqlite3PagerClose.isra.0 () from .../libsqlite3.so
#9  0x00007ffff5175bd7 in sqlite3BtreeClose.isra.0 () from .../libsqlite3.so
#10 0x00007ffff51766d8 in sqlite3LeaveMutexAndCloseZombie () from .../libsqlite3.so
#11 0x00007ffff5176fac in sqlite3Close () from .../libsqlite3.so
#12 0x00007ffde09062b1 in std::_Sp_counted_ptr<osgeo::proj::io::SQLiteHandle*, ...>::_M_dispose() () from .../libproj.so.25
#13 0x00007ffde0906c92 in osgeo::proj::io::SQLiteHandleCache::~SQLiteHandleCache() () from .../libproj.so.25
#14 0x00007ffff74450d1 in __run_exit_handlers () from .../libc.so.6
#15 0x00007ffff74451ae in exit () from .../libc.so.6
#16 0x00007ffff742b28c in __libc_start_call_main () from .../libc.so.6
#17 0x00007ffff742b338 in __libc_start_main_impl () from .../libc.so.6
#18 0x0000555555555085 in _start ()
```

## How to reproduce:

```c
#include <sqlite3.h>

__attribute__((destructor)) static void emit_log_at_exit(void)
{
  sqlite3_log(SQLITE_WARNING, "DINGUS");
}
```

```python
# driver.py
import ctypes, sys, apsw, apsw.bestpractice

apsw.bestpractice.library_logging()
apsw.Connection(":memory:").execute("select 1").fetchall()
# keep the C lib around until after exit
ctypes.CDLL(sys.argv[1], mode=ctypes.RTLD_GLOBAL)
print("driver done", flush=True)
```

Build the library against the same `libsqlite3` as apsw and run `python driver.py ./libatexitlog.so`:

```
driver done
Segmentation fault (core dumped)
exit code: 139
```